### PR TITLE
Fix HEROKU_CLI_EMAIN env var reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installs the [Heroku toolbelt][heroku-toolbelt] on a heroku dyno.
 ```shell
 heroku buildpacks:add https://github.com/Thermondo/heroku-cli-buildpack
 heroku config:set HEROKU_CLI_TOKEN=`heroku auth:token`
-heroku config:set HEROKU_CLI_EMAIN=`heroku auth:whoami`
+heroku config:set HEROKU_CLI_EMAIL=`heroku auth:whoami`
 ```
 
 ### Usage


### PR DESCRIPTION
I _think_ there's a typo in the README. This [line](https://github.com/Thermondo/heroku-cli-buildpack/blob/master/bin/compile#L12), and the behavior of the buildpack suggests that expected value should be HEROKU_CLI_EMAIL.